### PR TITLE
Cambio en función navigateTo

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -41,7 +41,7 @@ const renderView = (pathname, props = {}) => {
 
 export const navigateTo = (pathname, props = {}) => {
   // update window history with pushState
-  const URLvisited = window.location.hostname + pathname;
+  const URLvisited = window.location.origin + pathname;
   history.pushState({}, "", URLvisited);
   // render the view with the pathname and props
   renderView(pathname, props);


### PR DESCRIPTION
En la función navigateTo del archivo router.js, se cambia la propiedad window.location.hostname por window.location.origin